### PR TITLE
Remove trivial /std dependency

### DIFF
--- a/ini.ts
+++ b/ini.ts
@@ -1,7 +1,5 @@
-import * as eol from 'https://deno.land/std@0.51.0/fs/eol.ts'
-
 const isWindows = Deno.build.os == "windows";
-const EOL = isWindows ? eol.EOL.CRLF : eol.EOL.LF;
+const EOL = isWindows ? "\r\n" : "\n";
 
 export const parse = decode
 export const stringify = encode


### PR DESCRIPTION
I came here today to upgrade this std version, but after seeing that it's literally only used to fetch two string constants I decided to suggest removing the std import entirely. Nothing to upgrade now :)

This outdated std import shows up when when [visualizing modules such as my /x/aws_api](https://deno-visualizer.danopia.net/dependencies-of/x/aws_api@v0.2.1/examples/cloudwatch-emitter.ts?std=isolate)

Looks like CI is disabled, maybe from inactivity.